### PR TITLE
Fix duplicate interface definition errors (RN v0.40+)

### DIFF
--- a/RNBEMCheckBox/RNBEMCheckBoxManager.m
+++ b/RNBEMCheckBox/RNBEMCheckBoxManager.m
@@ -1,10 +1,10 @@
 #import "BEMCheckBox.h"
 #import "RNBEMCheckBoxManager.h"
 
-#import "RCTBridge.h"
-#import "RCTEventDispatcher.h"
-#import "UIView+React.h"
-#import "RCTConvert.h"
+#import <React/RCTBridge.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/UIView+React.h>
+#import <React/RCTConvert.h>
 
 @implementation RCTConvert (BEMCheckBox)
 


### PR DESCRIPTION
See breaking changes in React Native v0.40.0 

[https://github.com/facebook/react-native/releases/tag/v0.40.0](https://github.com/facebook/react-native/releases/tag/v0.40.0)