### PR TITLE
Added prop-types node module

### DIFF
--- a/BEMCheckBox.ios.js
+++ b/BEMCheckBox.ios.js
@@ -3,8 +3,9 @@
  * @flow
  */
 'use strict';
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import { StyleSheet, requireNativeComponent } from 'react-native';
+import PropTypes from 'prop-types';
 
 const RNBEMCheckBox = requireNativeComponent('RNBEMCheckBox', null);
 


### PR DESCRIPTION
Hi @torifat 

React as deprecated importing of PropTypes from react:

`import React, {Component, PropTypes} from "react";` 

They have created a separate node module prop-type for the same:

`import PropTypes from 'prop-types'`

In ReactNative >=0.49.0 it is throwing exception due to which app is not working

Can you please approve this merge request, so that in next release onwards we can get the fix for the same

Please let me know in case any discussion is needed

Thanks
Pranav