### PR TITLE
Fixing the flow syntax error

### DIFF
--- a/BEMCheckBox.ios.js
+++ b/BEMCheckBox.ios.js
@@ -44,7 +44,7 @@ export default class BEMCheckBox extends Component {
     );
   }
 
-  _onChange = (event: Object) => void = (event) => {
+  _onChange = (event: Object): void => {
     const { name, value } = event.nativeEvent;
     const { onValueChange, onAnimationEnd } = this.props;
     switch (name) {


### PR DESCRIPTION
Hi @torifat 

Receiving below syntax error at `_onChange` function while running the app:

<img width="532" alt="screen shot 2017-12-15 at 11 37 24 am" src="https://user-images.githubusercontent.com/28862892/34029311-d9e56e06-e18d-11e7-9479-6aa7058506b8.png">

After looking into issue and checking it on [flow/docs](https://flow.org/en/docs/types/functions/), I have changed the function declaration to below syntax and then it is working as expected

`_onChange = (event: Object) => void = (event) => {`

TO

`_onChange = (event: Object): void => {`

Can you please merge the raised PR, please let me know in case discussion is required for the same

Thanks
Pranav